### PR TITLE
Fix local/remote order

### DIFF
--- a/diag.sh
+++ b/diag.sh
@@ -11,8 +11,8 @@ done;
 
 for t in `ip tun show | grep 185.66.19`; do
 	echo "Test results for $t"
-	local=`echo $t | cut -d " " -f 4`
-	remote=`echo $t | cut -d " " -f 6`
+	remote=`echo $t | cut -d " " -f 4`
+	local=`echo $t | cut -d " " -f 6`
 	ping -I $local -i 0.01 -c 10000 -q $remote
 	mtr -a $local -i 0.1 -c 1000 -r -w $remote
 done;


### PR DESCRIPTION
Both iproute2 and busybox show the remote IP before the local IP. With the
wrong order, we see a 'ping: bind: Cannot assign requested address'.